### PR TITLE
feat: automatically stop all motors when a breakpoint is triggered

### DIFF
--- a/examples/motor-stop.rs
+++ b/examples/motor-stop.rs
@@ -5,7 +5,7 @@
 //! This example shows the `with_motor_stop(true)` feature. 
 //! It:
 //!
-//! 1. Spin any motors that are plugged into the bot at +6 V
+//! 1. Spin any motors that are plugged into the bot at +6 V (6000 mV)
 //! 2. Runs the debugger with `with_motor_stop(true)`
 //! 3. It then hits a breakpoint where all of the motors stop.
 //! 4. Then resumes normally; meaning all the motors spin again.
@@ -29,7 +29,7 @@
 //!
 //!   Possibly useful gdb commands once connected:
 //!
-//!   ```text
+//!   ```sh
 //!   (gdb) monitor help              # list all monitor commands
 //!   (gdb) monitor stop_motors       # check current auto-stop setting
 //!   (gdb) monitor stop_motors on    # enable (already on in this example but off by default)
@@ -47,11 +47,11 @@ use v5gdb::{debugger::V5Debugger, transport::StdioTransport};
 use vex_sdk::{V5_MAX_DEVICE_PORTS, vexDeviceGetByIndex, vexDeviceMotorVoltageSet};
 use vexide::prelude::*;
 
-/// set all detected motors to `voltage_mv` millivolts.
+/// Set all detected motors to `voltage_mv` millivolts.
 ///
-/// ts mirrors the loop in `motors::stop_all_motors`
-/// non-motor devices on a port should silently ignore the call
-/// (the sdk should no-ops if the device type does not match)
+/// This mirrors the loop in `motors::stop_all_motors`
+/// non-motor devices on a port should silently ignore this call
+/// (the sdk should no-ops if the device type does not match).
 fn set_all_motors(voltage_mv: i32) {
     for port in 0..V5_MAX_DEVICE_PORTS {
         unsafe {
@@ -82,19 +82,24 @@ async fn main(_peripherals: Peripherals) {
     println!("Motors will spin at +6 V, then stop automatically at the breakpoint.");
     println!("Connect GDB, then type 'c' to resume and watch motors restart.");
 
-    // Snstalls the debugger with auto motor stop enabled
+    // Installs the debugger with auto-motor stop enabled.
     //
     // `with_motor_stop(true)` is the new builder method.
     // You can also enable it at runtime from GDB with:
+    //
     // ```sh
     // (gdb) monitor stop_motors on
     // ```
+    //
+    // If you dont want this feature to be active, not using 
+    // this builder method, will set it to false by default.
+    
     v5gdb::install(
         V5Debugger::new(StdioTransport)
             .with_motor_stop(true),
     );
 
-    // spin motors so you can physically watch the motors running
+    // Spin motors so you can watch the motors running
     println!("Spinning motors at +6 V for 2 s...");
     set_all_motors(6_000); // 6 000 mV = 6 V
     sleep(Duration::from_secs(2)).await;
@@ -108,7 +113,7 @@ async fn main(_peripherals: Peripherals) {
     // the gdb console loop runs. 
     // the brain waits here for new gdb commands.
 
-    // after gdbs `c` (continue), execution resumes here.
+    // after gdb's `c` (continue), execution resumes here.
     println!("Resumed.  Motors will spin again and loop...");
 
     let mut iter = 0u32;

--- a/examples/motor-stop.rs
+++ b/examples/motor-stop.rs
@@ -31,9 +31,9 @@
 //!
 //!   ```sh
 //!   (gdb) monitor help              # list all monitor commands
-//!   (gdb) monitor stop_motors       # check current auto-stop setting
-//!   (gdb) monitor stop_motors on    # enable (already on in this example but off by default)
-//!   (gdb) monitor stop_motors off   # disable to test motors keep running
+//!   (gdb) monitor autostop ?        # check current auto-stop setting
+//!   (gdb) monitor autostop true     # enable (already on in this example but off by default)
+//!   (gdb) monitor autostop false    # disable to test motors keep running
 //!   (gdb) monitor stop              # manually stop motors right now
 //!   (gdb) c                         # continue (motors spin again)
 //!   (gdb) break motor_stop_loop     # set a named-function breakpoint
@@ -66,7 +66,7 @@ fn set_all_motors(voltage_mv: i32) {
 }
 
 
-// named function so gdbs `break motor_stop_loop` works
+// named function so gdbs `break motor_stop_loop` command works
 #[inline(never)]
 fn motor_stop_loop(iteration: u32) -> u32 {
     iteration.wrapping_add(1)
@@ -88,10 +88,10 @@ async fn main(_peripherals: Peripherals) {
     // You can also enable it at runtime from GDB with:
     //
     // ```sh
-    // (gdb) monitor stop_motors on
+    // (gdb) monitor autostop true
     // ```
     //
-    // If you dont want this feature to be active, not using 
+    // If you do not want this feature to be active, not using 
     // this builder method, will set it to false by default.
     
     v5gdb::install(

--- a/examples/motor-stop.rs
+++ b/examples/motor-stop.rs
@@ -1,0 +1,121 @@
+//! Motor stop on breakpoint example
+//!
+//! # What this demos
+//!
+//! This example shows the `with_motor_stop(true)` feature. 
+//! It:
+//!
+//! 1. Spin any motors that are plugged into the bot at +6 V
+//! 2. Runs the debugger with `with_motor_stop(true)`
+//! 3. It then hits a breakpoint where all of the motors stop.
+//! 4. Then resumes normally; meaning all the motors spin again.
+//!
+//!
+//! # How to build and upload
+//!
+//!   ```sh
+//!   cargo v5 run --example motor_stop
+//!   ```
+//!
+//! # How to attach GDB
+//!
+//!   In a second terminal (The brain should be connected through usb):
+//!
+//!   ```sh
+//!   arm-none-eabi-gdb \
+//!       target/armv7a-vex-v5/debug/examples/motor_stop \
+//!       -ex "target extended-remote | cargo v5 terminal"
+//!   ```
+//!
+//!   Possibly useful gdb commands once connected:
+//!
+//!   ```text
+//!   (gdb) monitor help              # list all monitor commands
+//!   (gdb) monitor stop_motors       # check current auto-stop setting
+//!   (gdb) monitor stop_motors on    # enable (already on in this example but off by default)
+//!   (gdb) monitor stop_motors off   # disable to test motors keep running
+//!   (gdb) monitor stop              # manually stop motors right now
+//!   (gdb) c                         # continue (motors spin again)
+//!   (gdb) break motor_stop_loop     # set a named-function breakpoint
+//!   (gdb) info registers            # inspect CPU registers
+//!   (gdb) disconnect                # detach cleanly
+//!   ```
+
+use std::time::Duration;
+
+use v5gdb::{debugger::V5Debugger, transport::StdioTransport};
+use vex_sdk::{V5_MAX_DEVICE_PORTS, vexDeviceGetByIndex, vexDeviceMotorVoltageSet};
+use vexide::prelude::*;
+
+/// set all detected motors to `voltage_mv` millivolts.
+///
+/// ts mirrors the loop in `motors::stop_all_motors`
+/// non-motor devices on a port should silently ignore the call
+/// (the sdk should no-ops if the device type does not match)
+fn set_all_motors(voltage_mv: i32) {
+    for port in 0..V5_MAX_DEVICE_PORTS {
+        unsafe {
+            let dev = vexDeviceGetByIndex(port as u32);
+            if dev.is_null() {
+                continue; 
+            }
+
+            vexDeviceMotorVoltageSet(dev, voltage_mv);
+        }
+    }
+}
+
+
+// named function so gdbs `break motor_stop_loop` works
+#[inline(never)]
+fn motor_stop_loop(iteration: u32) -> u32 {
+    iteration.wrapping_add(1)
+}
+
+
+#[vexide::main(banner(enabled = false))]
+async fn main(_peripherals: Peripherals) {
+    colored::control::set_override(true);
+    clang_log::init(log::Level::max(), "v5gdb(motor_stop)");
+
+    println!("*** v5gdb motor-stop-on-breakpoint example ***");
+    println!("Motors will spin at +6 V, then stop automatically at the breakpoint.");
+    println!("Connect GDB, then type 'c' to resume and watch motors restart.");
+
+    // Snstalls the debugger with auto motor stop enabled
+    //
+    // `with_motor_stop(true)` is the new builder method.
+    // You can also enable it at runtime from GDB with:
+    // ```sh
+    // (gdb) monitor stop_motors on
+    // ```
+    v5gdb::install(
+        V5Debugger::new(StdioTransport)
+            .with_motor_stop(true),
+    );
+
+    // spin motors so you can physically watch the motors running
+    println!("Spinning motors at +6 V for 2 s...");
+    set_all_motors(6_000); // 6 000 mV = 6 V
+    sleep(Duration::from_secs(2)).await;
+
+    // Breakpoint
+    // the motors will stop here
+    println!("Triggering breakpoint -> motors should stop **now**.");
+    v5gdb::breakpoint!();
+    // At this point the debugger fires, `stop_all_motors()` is called inside
+    // `handle_debug_event()` because `stop_motors_on_break` is equal to `true`, and then
+    // the gdb console loop runs. 
+    // the brain waits here for new gdb commands.
+
+    // after gdbs `c` (continue), execution resumes here.
+    println!("Resumed.  Motors will spin again and loop...");
+
+    let mut iter = 0u32;
+    loop {
+        set_all_motors(6_000);
+        iter = motor_stop_loop(iter);
+        println!("Loop iteration {iter}");
+        sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     debugger::sdk::InternalBreakpoint,
     exceptions::DebugEventContext,
     gdb_target::{V5Target, breakpoint::hardware::Specificity},
+    motors::stop_all_motors,
     sys::{DebuggerSystem, System},
     transport::TransportError,
 };
@@ -49,6 +50,13 @@ where
     S: Connection<Error = TransportError> + ConnectionExt,
 {
     state: Mutex<DebuggerState<'static, S>>,
+    /// Whether to automatically stop all motors when a breakpoint fires.
+    ///
+    /// This is set via [`V5Debugger::with_motor_stop`] at construction time and
+    /// propagated into [`V5Target::stop_motors_on_break`] during
+    /// [`Debugger::initialize`]. It can subsequently be changed at runtime
+    /// through the `monitor stop_motors on/off` GDB command.
+    stop_motors_on_break: bool,
 }
 
 impl<S> V5Debugger<S>
@@ -56,6 +64,10 @@ where
     S: Connection<Error = TransportError> + ConnectionExt,
 {
     /// Creates a new debugger.
+    ///
+    /// Auto motor-stop on breakpoint is **disabled** by default. Enable it with
+    /// [`with_motor_stop`](Self::with_motor_stop), or toggle it at runtime from
+    /// GDB using `monitor stop_motors on`.
     #[must_use]
     pub fn new(stream: S) -> Self {
         const GDB_PACKET_BUFFER_SIZE: usize = 4096;
@@ -87,7 +99,43 @@ where
                 target,
                 internal_breaks: None,
             }),
+            stop_motors_on_break: false,
         }
+    }
+
+    /// config wether all motors should be auto stopped when ever a
+    /// breakpoint is triggered.
+    ///
+    /// when enabled, it calls `vexDeviceMotorVoltageSet(device, 0)` for
+    /// every smart port on the brain when a breakpoint fires; 
+    /// before the gdb console loop even starts.  
+    /// this means the robot stays put and stops, any motion
+    /// when you inspect state.
+    ///
+    /// The setting can also be toggled live from gdb at any time through :
+    ///
+    /// ```
+    /// (gdb) monitor stop_motors on
+    /// (gdb) monitor stop_motors off
+    /// (gdb) monitor stop_motors
+    /// ```
+    ///
+    /// Defaults to `false`.
+    ///
+    /// # Example :
+    ///
+    /// ```rust,no_run
+    /// use v5gdb::{debugger::V5Debugger, transport::StdioTransport};
+    ///
+    /// v5gdb::install(
+    ///     V5Debugger::new(StdioTransport)
+    ///         .with_motor_stop(true)
+    /// );
+    /// ```
+    #[must_use]
+    pub fn with_motor_stop(mut self, enabled: bool) -> Self {
+        self.stop_motors_on_break = enabled;
+        self
     }
 
     /// Returns the debugger's internal state.
@@ -106,7 +154,14 @@ where
         state.register_internal_breakpoints();
         System::initialize(&mut state.target);
         crate::sdk::competition::install_override();
-        log::debug!("Debugger initialized");
+
+        // copy the compile time default into the target state
+        // after this point the gdb,
+        //      `monitor stop_motors`,
+        // command is the way to change the flag
+        state.target.stop_motors_on_break = self.stop_motors_on_break;
+
+        log::debug!("Debugger initialized (stop_motors_on_break={})", self.stop_motors_on_break);
     }
 
     unsafe fn handle_debug_event(&self, ctx: &mut DebugEventContext) -> bool {
@@ -132,6 +187,23 @@ where
             log::error!("**** v5gdb: BREAKPOINT TRIGGERED ****");
             log::error!("Your program has been paused. Please connect a debugger.")
         });
+
+        // auto motor stop on breakpoint
+        //
+        // stop all motors before entering the gdb console loop
+        // This prevents the bot from driving away (or any motor movement, 
+        // but most usefull for drivetrain) while execution is paused.
+        //
+        // check the flag from `target.stop_motors_on_break` (not
+        // `self.stop_motors_on_break`) 
+        // 
+        // so that live changes via
+        // `monitor stop_motors on / off` take effect immediately on the next
+        // breakpoint without restarting the program.
+        if state.target.stop_motors_on_break {
+            log::debug!("auto motor-stop triggered by breakpoint");
+            stop_all_motors();
+        }
 
         let was_locked = state.target.hw_manager.locked();
         state.target.hw_manager.set_locked(false);

--- a/src/gdb_target/mod.rs
+++ b/src/gdb_target/mod.rs
@@ -68,6 +68,18 @@ pub struct V5Target {
     /// If set, breakpoints are being used to single step. Report any hardware breaks as single
     /// steps instead of normal breakpoints.
     pub single_step_request: Option<SingleStepRequest>,
+
+    /// when it is `true`, all motors are stopped when a breakpoint is triggered
+    ///
+    /// this should prevents the robot from moving while the debugger has paused
+    /// execution. It can be toggled at runtime with the gdb monitor commands
+    ///
+    /// `monitor stop_motors on` / `monitor stop_motors off`, 
+    /// or config'ed at startup via
+    /// [`crate::debugger::V5Debugger::with_motor_stop`].
+    ///
+    /// defaults to `false`.
+    pub stop_motors_on_break: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,6 +108,7 @@ impl V5Target {
             breaks: [None; _],
             single_step_request: None,
             hw_manager: HwBreakpointManager::setup(devcfg),
+            stop_motors_on_break: false,
         }
     }
 

--- a/src/gdb_target/monitor.rs
+++ b/src/gdb_target/monitor.rs
@@ -2,6 +2,7 @@ use core::{iter, str::FromStr};
 
 use gdbstub::target::ext::monitor_cmd::{ConsoleOutput, MonitorCmd};
 use log::LevelFilter;
+#[allow(unused_imports)]
 use vex_sdk::*;
 
 use crate::{

--- a/src/gdb_target/monitor.rs
+++ b/src/gdb_target/monitor.rs
@@ -18,8 +18,8 @@ const HELP_MSG: &str = "
 Monitor commands:
     help                                Show this help message.
     stop                                Immediately stop all motors right now.
-    stop_motors                         Show whether auto-stop on breakpoint is enabled.
-    stop_motors (on | off)              Enable or disable automatic motor stop on breakpoint.
+    autostop ?                          Show whether auto-stop on breakpoint is enabled.
+    autostop (true | false)             Enable or disable automatic motor stop on breakpoint.
     ctrl [partner]                      View controller state, primary (default) or partner.
     comp                                View competition state.
     comp (driver | auton | disabled)    Override competition mode.
@@ -50,14 +50,15 @@ impl MonitorCmd for V5Target {
                 gdbstub::outputln!(out, "All motors stopped.");
             }
 
-            // `monitor stop_motors [on | off]`
+            // `monitor autostop [true | false]`
             //
-            // with no args:      print current setting.
-            // with "on":         enable auto-stop on every breakpoint.
-            // with "off":        disable auto-stop.
-            "stop_motors" => {
+            // with no args:        tells the user what commands they can use.
+            // with "true":         enable auto-stop on every breakpoint.
+            // with "false":        disable auto-stop.
+            // with "?"             prints the state of auto-stop.
+            "autostop" => {
                 match args.next() {
-                    Some("on") => {
+                    Some("true") => {
                         self.stop_motors_on_break = true;
                         gdbstub::outputln!(
                             out,
@@ -65,30 +66,39 @@ impl MonitorCmd for V5Target {
                              All motors will be stopped immediately whenever a breakpoint fires."
                         );
                     }
-                    Some("off") => {
+                    Some("false") => {
                         self.stop_motors_on_break = false;
                         gdbstub::outputln!(
                             out,
                             "Auto motor-stop on breakpoint: DISABLED."
                         );
                     }
-                    Some(unknown) => {
-                        gdbstub::outputln!(
-                            out,
-                            "Unknown argument '{unknown}'. Use 'on' or 'off'.\n\
-                             Example: `monitor stop_motors on`"
-                        );
-                    }
-                    None => {
-                        let state = if self.stop_motors_on_break {
+                    Some("?") => {
+                        let stop_state = if self.stop_motors_on_break {
                             "ENABLED"
                         } else {
                             "DISABLED"
                         };
+
                         gdbstub::outputln!(
                             out,
                             "auto motor-stop on breakpoint: {state}.\n\
-                             Use `monitor stop_motors on` or `monitor stop_motors off` to change."
+                             Use `monitor autostop true` or `monitor autostop false` to change the state."
+                        );
+                    }
+                    Some(unknown) => {
+                        gdbstub::outputln!(
+                            out,
+                            "Unknown argument '{unknown}'. Use 'true' or 'false' or '?'.\n\
+                             Example: `monitor autostop true`"
+                        );
+                    }
+                    None => {
+                        gdbstub::outputln!(
+                            out,
+                            "Please include valid arguments this includes: \n\
+                             `autostop ?`                Show whether auto-stop on breakpoint is enabled.\n\
+                             `autostop (true | false)`   Enable or disable automatic motor stop on breakpoint."
                         );
                     }
                 }

--- a/src/gdb_target/monitor.rs
+++ b/src/gdb_target/monitor.rs
@@ -6,6 +6,7 @@ use vex_sdk::*;
 
 use crate::{
     gdb_target::V5Target,
+    motors::stop_all_motors,
     sdk::competition,
     sys::{DebuggerSystem, System},
 };
@@ -16,7 +17,9 @@ const MONITOR_DESCRIPTION: &str =
 const HELP_MSG: &str = "
 Monitor commands:
     help                                Show this help message.
-    stop                                Stop all motors.
+    stop                                Immediately stop all motors right now.
+    stop_motors                         Show whether auto-stop on breakpoint is enabled.
+    stop_motors (on | off)              Enable or disable automatic motor stop on breakpoint.
     ctrl [partner]                      View controller state, primary (default) or partner.
     comp                                View competition state.
     comp (driver | auton | disabled)    Override competition mode.
@@ -39,17 +42,58 @@ impl MonitorCmd for V5Target {
         let cmd = args.next().unwrap_or("help");
 
         match cmd {
+            // `monitor stop`
+            // stop all motors right now, regardless of the
+            // auto-stop setting.
             "stop" => {
-                for port_num in 0..V5_MAX_DEVICE_PORTS {
-                    unsafe {
-                        let device = vexDeviceGetByIndex(port_num as u32);
-                        if device.is_null() {
-                            break;
-                        }
-                        vexDeviceMotorVoltageSet(device, 0);
+                stop_all_motors();
+                gdbstub::outputln!(out, "All motors stopped.");
+            }
+
+            // `monitor stop_motors [on | off]`
+            //
+            // with no args:      print current setting.
+            // with "on":         enable auto-stop on every breakpoint.
+            // with "off":        disable auto-stop.
+            "stop_motors" => {
+                match args.next() {
+                    Some("on") => {
+                        self.stop_motors_on_break = true;
+                        gdbstub::outputln!(
+                            out,
+                            "auto motor-stop on breakpoint: ENABLED.\n\
+                             All motors will be stopped immediately whenever a breakpoint fires."
+                        );
+                    }
+                    Some("off") => {
+                        self.stop_motors_on_break = false;
+                        gdbstub::outputln!(
+                            out,
+                            "Auto motor-stop on breakpoint: DISABLED."
+                        );
+                    }
+                    Some(unknown) => {
+                        gdbstub::outputln!(
+                            out,
+                            "Unknown argument '{unknown}'. Use 'on' or 'off'.\n\
+                             Example: `monitor stop_motors on`"
+                        );
+                    }
+                    None => {
+                        let state = if self.stop_motors_on_break {
+                            "ENABLED"
+                        } else {
+                            "DISABLED"
+                        };
+                        gdbstub::outputln!(
+                            out,
+                            "auto motor-stop on breakpoint: {state}.\n\
+                             Use `monitor stop_motors on` or `monitor stop_motors off` to change."
+                        );
                     }
                 }
             }
+
             "ctrl" => gdbstub::outputln!(out, "Unimplemented"), // TODO
             "comp" => {
                 let change = args.next();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod debugger;
 pub mod exceptions;
 #[cfg(target_arch = "arm")]
 pub mod gdb_target;
+pub mod motors;
 #[cfg(target_arch = "arm")]
 mod sdk;
 mod sys;
@@ -33,6 +34,7 @@ pub mod debugger {
         S: Connection<Error = TransportError> + ConnectionExt,
     {
         _stream: spin::Mutex<S>,
+        _stop_motors_on_break: bool,
     }
 
     impl<S: Connection<Error = TransportError> + ConnectionExt> V5Debugger<S> {
@@ -41,7 +43,26 @@ pub mod debugger {
         pub fn new(stream: S) -> Self {
             Self {
                 _stream: spin::Mutex::new(stream),
+                _stop_motors_on_break: false,
             }
+        }
+
+        /// config wether all motors should be automatically stopped whenever
+        /// a breakpoint is triggered.
+        ///
+        /// Defaults to `false`; when `true`, every motor on every port is set to
+        /// 0 the moment a breakpoint fires, before the GDB console loop runs
+        ///
+        /// This can also be toggled at runtime from GDB with
+        ///
+        /// ```
+        /// monitor stop_motors on
+        /// monitor stop_motors off
+        /// ```
+        #[must_use]
+        pub fn with_motor_stop(mut self, enabled: bool) -> Self {
+            self._stop_motors_on_break = enabled;
+            self
         }
     }
 
@@ -51,7 +72,7 @@ pub mod debugger {
     {
         fn initialize(&self) {}
 
-        unsafe fn handle_debug_event(&self, _ctx: &mut crate::exceptions::DebugEventContext) {
+        unsafe fn handle_debug_event(&self, _ctx: &mut crate::exceptions::DebugEventContext) -> bool {
             unimplemented!()
         }
     }

--- a/src/motors.rs
+++ b/src/motors.rs
@@ -1,0 +1,40 @@
+//! motor controls utits
+//!
+//! This mod provides helpers for stopping all connected motors on the
+//! brain. It is used both by the `monitor stop` command (manual stop) and by
+//! the auto stop-on-breakpoint feature
+
+use vex_sdk::{V5_MAX_DEVICE_PORTS, vexDeviceGetByIndex, vexDeviceMotorVoltageSet};
+
+
+/// Immediately stops every motor connected to the brain by setting its
+/// voltage to 0
+///
+/// ports that have no device connected are silently skipped. The loop does
+/// not short circuit on a null device handle so that non contiguous motor
+/// configurations (e.g. motors on ports 1 and 5 with nothing on 2–4) can end up
+/// being handled correctly.
+
+#[cfg(target_arch = "arm")]
+pub fn stop_all_motors() {
+    for port_num in 0..V5_MAX_DEVICE_PORTS {
+        unsafe {
+            let device = vexDeviceGetByIndex(port_num as u32);
+            if device.is_null() {
+                // Nothing plugged in to this port -> so skip but keep going over ports
+                // must not `break` here: ports can be noncontiguous; meaning a
+                // null handle does not mean there are no more devices (I think maybe a spot for review)
+                continue;
+            }
+            // setting voltage to 0 immediately cuts power to the motor
+            // this works for both 11W and 5.5W motors
+            vexDeviceMotorVoltageSet(device, 0);
+        }
+    }
+}
+
+/// No-op stub
+#[cfg(not(target_arch = "arm"))]
+pub fn stop_all_motors() {
+
+}

--- a/src/motors.rs
+++ b/src/motors.rs
@@ -12,9 +12,8 @@ use vex_sdk::{V5_MAX_DEVICE_PORTS, vexDeviceGetByIndex, vexDeviceMotorVoltageSet
 ///
 /// ports that have no device connected are silently skipped. The loop does
 /// not short circuit on a null device handle so that non contiguous motor
-/// configurations (e.g. motors on ports 1 and 5 with nothing on 2–4) can end up
+/// configurations (e.g. motors on ports 1 and 5 with no motors on ports 2-4) can end up
 /// being handled correctly.
-
 #[cfg(target_arch = "arm")]
 pub fn stop_all_motors() {
     for port_num in 0..V5_MAX_DEVICE_PORTS {


### PR DESCRIPTION
## Summary
Adds a configurable feature that stops all connected Smart Motors (11W and 5,5W) when a breakpoint fires, before the GDB console loop even begins. This prevents a robot from driving away, and all motion in general.

## Motivation
I want to learn the codebase, and I generally do that well by adding something to it.

### API changed

```rust
// sets the default at construction time (persists) :
v5gdb::install(
    V5Debugger::new(StdioTransport)
        .with_motor_stop(true),
);

// Or leave it off (the default) and toggle it live from gdb :
// (gdb) monitor stop_motors on
// (gdb) monitor stop_motors off
// (gdb) monitor stop_motors                 # prints current state
// (gdb) monitor stop                        # one-shot manual stop, always available
```

### Behaviour notes
- Default is false; meaning no change in behaviour for existing users.
- Live toggle - `monitor stop_motors` `on`/`off` takes effect on the very next breakpoint without having to restarting the program.
- Single step is unaffected - the auto-stop only fires on the initial breakpoint entry (`show_debug_console` path), not on each single step instruction. Calling `stop_all_motors()` on every single instruction would make stepping unusably slow and would clear motor state the user may be observing.


### Testing
I tested on a physical brain didn't really see how testing with Qemu would help
